### PR TITLE
Tiny fixes

### DIFF
--- a/scripts/communityScripts/armored-chat/armored_chat.js
+++ b/scripts/communityScripts/armored-chat/armored_chat.js
@@ -185,6 +185,7 @@
                                 enabled: event.value,
                             })
                         );
+                        break;
                 }
 
                 break;

--- a/scripts/communityScripts/armored-chat/armored_chat.js
+++ b/scripts/communityScripts/armored-chat/armored_chat.js
@@ -166,16 +166,6 @@
                 _sendMessage(event.message, event.channel);
                 break;
             case "setting_change":
-                if (event.setting === "worldspace_chat_bubbles") {
-                    settings.use_chat_bubbles = event.value;
-                    Messages.sendLocalMessage(
-                        "ChatBubbles-Config",
-                        JSON.stringify({
-                            enabled: event.value,
-                        })
-                    );
-                    break;
-                }
 
                 // Set the setting value, and save the config
                 settings[event.setting] = event.value; // Update local settings
@@ -188,6 +178,13 @@
                             ? Desktop.PresentationMode.NATIVE
                             : Desktop.PresentationMode.VIRTUAL;
                         break;
+                    case "use_chat_bubbles":
+                        Messages.sendLocalMessage(
+                            "ChatBubbles-Config",
+                            JSON.stringify({
+                                enabled: event.value,
+                            })
+                        );
                 }
 
                 break;
@@ -299,9 +296,6 @@
     }
     function _loadSettings() {
         settings = Settings.getValue("ArmoredChat-Config", settings);
-
-        const chatBubbleSettings = Settings.getValue("ChatBubbles-Config", { enabled: true });
-        if (chatBubbleSettings.enabled) { settings.use_chat_bubbles = true; }
 
         if (messageHistory) {
             // Load message history

--- a/scripts/communityScripts/armored-chat/armored_chat.qml
+++ b/scripts/communityScripts/armored-chat/armored_chat.qml
@@ -407,7 +407,7 @@ Rectangle {
                         anchors.verticalCenter: parent.verticalCenter
 
                         onCheckedChanged: {
-                            toScript({type: 'setting_change', setting: 'worldspace_chat_bubbles', value: checked})
+                            toScript({type: 'setting_change', setting: 'use_chat_bubbles', value: checked})
                         }
                     }
                 }


### PR DESCRIPTION
This changes the "setting_change" handling to rely on the functions below it to handle the desired settings adjustment.
```javascript
settings[event.setting] = event.value; // Update local settings
_saveSettings(); // Save local settings
```
The localMessage that is sent to the chatBubbles.js code has been moved to after the settings are saved.

This was redundant after one of your previous changes so It was removed:
```javascript
        const chatBubbleSettings = Settings.getValue("ChatBubbles-Config", { enabled: true });
        if (chatBubbleSettings.enabled) { settings.use_chat_bubbles = true; }
```


Please test this and let me know if it works for you!